### PR TITLE
English Option in Example

### DIFF
--- a/Assets/ScriptExample/Resources/script.txt
+++ b/Assets/ScriptExample/Resources/script.txt
@@ -1,6 +1,11 @@
 delay 500
 
 *start
+あなたは日本語を話せますか？
+(Do you speak Japanese?)
+gesture *start-ja, *start-en
+
+*start-ja
 わたしを お城まで 連れて
 帰ってくださいますのね？
 gesture *yes, *no
@@ -15,6 +20,22 @@ goto *start
 *no
 delay 300
 そんな ひどい…。
+delay 1500
+goto *start
+
+*start-en
+Would you please bring me to your castle?
+gesture *yes-en, *no-en
+
+*yes-en
+delay 300
+Yay! I'm glad.
+delay 1500
+goto *start
+
+*no-en
+delay 300
+Aw... Why not? *pout*
 delay 1500
 goto *start
 

--- a/Assets/ScriptExample/Scripts/ScriptEngine.cs
+++ b/Assets/ScriptExample/Scripts/ScriptEngine.cs
@@ -88,7 +88,7 @@ namespace ScriptExample
             switch (command)
             {
                 case "gesture":
-                    var r = new Regex(@"^gesture\s+\*(\w+)\s*,\s*\*(\w+)$");
+                    var r = new Regex(@"^gesture\s+\*([\w-]+)\s*,\s*\*([\w-]+)$");
                     var m = r.Match(lines[cursor]);
 
                     if (m.Groups.Count == 3)


### PR DESCRIPTION
When I first tried the project, I wasn't sure if my yes/no nods were working or not, so I updated the script to include an English option. This adds a question at the beginning that asks if you speak japanese in both English and Japanese. (I used Google Translate, so please change if it isn't worded appropriately.)

I also added support for '-' in label names to support postfix like '-en' and '-ja'.